### PR TITLE
Bulk add products to cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ const results = await picnicClient.catalog.search("Affligem blond");
 // Add a product to the cart
 await picnicClient.cart.addProductToCart(11295810, 2);
 
+// Bulk add products to the cart using selling-unit ids as keys
+await picnicClient.cart.addProductsToCart({
+  s11295810: 2,
+  s10000123: 1,
+});
+
 // Get available delivery slots
 const slots = await picnicClient.cart.getDeliverySlots();
 
@@ -78,6 +84,8 @@ The client exposes the following domain services, each grouping a set of related
 | **User Onboarding** | `client.userOnboarding` | Household/business details and push subscriptions. |
 
 Each service method is fully typed — explore the type definitions under `src/domains/<service>/types.ts` for request and response shapes.
+
+For larger baskets such as recipes or weekly menus, prefer `client.cart.addProductsToCart(...)` over repeated `addProductToCart(...)` calls.
 
 ## Contributing
 

--- a/src/domains/cart/cart.test.ts
+++ b/src/domains/cart/cart.test.ts
@@ -1,0 +1,37 @@
+import { CartService } from "./service";
+import HttpClient from "../../http-client";
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+let cart: CartService;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  cart = new CartService(new HttpClient({ authKey: "initial-auth-key" }));
+});
+
+describe("CartService - addProductsToCart", () => {
+  it("should send the correct bulk add request", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      body: {},
+      json: () => Promise.resolve({ id: "cart-id" }),
+    });
+
+    const products = {
+      s11295810: 2,
+      s10000123: 1,
+    };
+
+    await cart.addProductsToCart(products);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/cart/products/add"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify(products),
+      }),
+    );
+  });
+});

--- a/src/domains/cart/service.ts
+++ b/src/domains/cart/service.ts
@@ -36,6 +36,14 @@ export class CartService {
   }
 
   /**
+   * Adds multiple products to the shopping cart in a single request.
+   * @param {Record<string, number>} products A map of selling unit ids to quantities.
+   */
+  addProductsToCart(products: Record<string, number>): Promise<Cart> {
+    return this.http.sendRequest<Record<string, number>, Cart>("POST", `/cart/products/add`, products);
+  }
+
+  /**
    * Removes a product from the shopping cart.
    * @param {string} productId The id of the product to remove.
    * @param {number} [count=1] The amount of this product to remove.


### PR DESCRIPTION
## Summary

This adds a public `CartService.addProductsToCart()` method for Picnic's bulk cart-add endpoint.

It exposes `POST /cart/products/add` as a first-class cart API instead of requiring consumers to loop `addProductToCart()` manually.

## Changes

- add `cart.addProductsToCart(products: Record<string, number>)`
- add a unit test for request path and payload shape
- document bulk cart adds in the README

## Why

As discussed in issue #37, previous approach was to call `addProductToCart()` in a loop, which is slow and risks (in extreme cases) to trigger Picnic to block you.

This PR updates the library with a verified bulk-add capability that is useful for larger baskets such as recipes, week menus, and other multi-product flows.

## Notes

- this is additive and non-breaking
- existing single-item methods remain unchanged for compatibility
- `addProductToCart()` is still useful for single-item mutations and flows that use `sellingUnitContext[]`

## Validation

- added Jest coverage for the request shape
- verified live against a real authenticated Picnic session:
  - bulk add via `POST /cart/products/add` works
  - the obvious symmetric bulk-remove guess `POST /cart/products/remove` returned `404 Not Found`, so this PR intentionally covers bulk add only

## Agentic coding
Used AGENDT.md and other documents with CODEX to clean up this PR and adhere to requested guidelines.