### PR TITLE
Update default agent to 1.236.1-15553

### DIFF
--- a/lib/http-client.js
+++ b/lib/http-client.js
@@ -11,7 +11,7 @@ class HttpClient {
         this.authKey = options?.authKey || null;
         this.url = options?.url || `https://storefront-prod.${this.countryCode.toLowerCase()}.picnicinternational.com/api/${this.apiVersion}`;
         this.deviceId = options?.deviceId || "3C417201548B2E3B";
-        this.agent = options?.agent || "30100;1.228.1-15480;";
+        this.agent = options?.agent || "30100;1.236.1-15553;";
     }
     get baseHeaders() {
         return {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -18,7 +18,7 @@ export default class HttpClient {
     this.authKey = options?.authKey || null;
     this.url = options?.url || `https://storefront-prod.${this.countryCode.toLowerCase()}.picnicinternational.com/api/${this.apiVersion}`;
     this.deviceId = options?.deviceId || "3C417201548B2E3B";
-    this.agent = options?.agent || "30100;1.228.1-15480;";
+    this.agent = options?.agent || "30100;1.236.1-15553;";
   }
 
   get baseHeaders(): Record<string, string> {


### PR DESCRIPTION
Updates the default `agent` string from `30100;1.228.1-15480;` to `30100;1.236.1-15553;`.

## Changes

- `src/http-client.ts` — updated default agent string
- `lib/http-client.js` — rebuilt compiled output

## Source

Version and build number taken directly from the decompiled AndroidManifest of the latest APK:
- `android:versionName="1.236.1"`
- `android:versionCode="15553"`

Client ID (`30100`) confirmed unchanged via JWT claim (`pc:clid`) from a fresh login.

## Verification

Smoke-tested live against the production API — all routes pass:
- `user.checkForUpdates` ✅
- `user.getUserDetails` ✅
- `cart.getCart` ✅
- `catalog.search` ✅
- `catalog.getSuggestions` ✅
- `catalog.getImage` ✅ (8069 bytes)
- `app.getPage` ✅